### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-haven-ai>=0.0
+haven-ai==0.6.7


### PR DESCRIPTION
Latest release of haven-ai doesn't have shrink2roi utility function. Suggested version of haven-ai works fine for replication of results.