### PR TITLE
Update fcn8_resnet.py

### DIFF
--- a/src/models/base_networks/fcn8_resnet.py
+++ b/src/models/base_networks/fcn8_resnet.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 import torch
 import torch.nn.functional as F
 import numpy as np
-from skimage.morphology import watershed
+from skimage.segmentation import watershed
 from skimage.segmentation import find_boundaries
 from scipy import ndimage
  


### PR DESCRIPTION
There was a pointer from morphology to a function that is located in segmentation. Needs to be updated to match the more modern scikit-image version.